### PR TITLE
dhcp-to-dns: add support for pool name in fqdn

### DIFF
--- a/dhcp-to-dns
+++ b/dhcp-to-dns
@@ -10,6 +10,7 @@
 :global HostNameInZone;
 :global Identity;
 :global PrefixInZone;
+:global PoolInZone;
 
 :global CharacterReplace;
 :global IfThenElse;
@@ -46,7 +47,12 @@
     [ $CharacterReplace ($LeaseVal->"mac-address") ":" "-" ] \
     [ $CharacterReplace ($LeaseVal->"host-name") " " "" ] ];
 
-  :local Fqdn ($HostName . "." . $Zone);
+  :local Server [ / ip dhcp-server find where name=($LeaseVal->"server") ];
+  :local ServerVal [ / ip dhcp-server get $Server ];
+  :local Pool ($ServerVal->"address-pool");
+  :local ZoneVal ([ $IfThenElse ($PoolInZone = true) ($Pool . ".") ] . $Zone);
+
+  :local Fqdn ($HostName . "." . $ZoneVal);
   :local DnsRecord [ / ip dns static find where name=$Fqdn ];
   :if ([ :len $DnsRecord ] > 0) do={
     :local DnsIp [ / ip dns static get $DnsRecord address ];

--- a/doc/dhcp-to-dns.md
+++ b/doc/dhcp-to-dns.md
@@ -33,6 +33,7 @@ The configuration goes to `global-config-overlay`, these are the parameters:
 
 * `Domain`: the domain used for dns records
 * `HostNameInZone`: whether or not to add the dhcp/dns server's hostname
+* `PoolInZone`: whether or not to add the dhcp server's pool name
 
 See also
 --------

--- a/global-config
+++ b/global-config
@@ -14,6 +14,7 @@
 :global Domain "example.com";
 :global HostNameInZone true;
 :global PrefixInZone true;
+:global PoolInZone false;
 
 # These addresses are used to send e-mails to. The to-address needs
 # to be filled; cc-address can be empty, one address or a comma


### PR DESCRIPTION
This adds support for pool names in the fqdn. I use it for a simple DMZ setup in my home network and would love to see it upstreamed. It works as expected for me but to be honest I understand only half the code.