### PR TITLE
always select first lease from dhcp-server

### DIFF
--- a/collect-wireless-mac.capsman
+++ b/collect-wireless-mac.capsman
@@ -33,8 +33,8 @@ $ScriptLock "collect-wireless-mac.capsman";
     :local HostName "no dhcp lease";
     :local Lease [ / ip dhcp-server lease find where mac-address=$Mac dynamic=yes status=bound ];
     :if ([ :len $Lease ] > 0) do={
-      :set Address [ / ip dhcp-server lease get $Lease address ];
-      :set HostName [ / ip dhcp-server lease get $Lease host-name ];
+      :set Address [ / ip dhcp-server lease get [:pick $Lease 0 ] address ];
+      :set HostName [ / ip dhcp-server lease get [:pick $Lease 0 ] host-name ];
       :if ([ :len $HostName ] = 0) do={
         :set HostName "no hostname";
       }


### PR DESCRIPTION
collect-wireless-mac.capsman fails at setting the hostname when there are multiple leases for a mac address

In line 36 and 37 the hostname gets set from the data the lease. When there is more than one lease for a specific mac address this fails with the message "invalid internal item number".
More than one lease for a mac address is possible, if you have more than one SSID on a capsman and a single device can login into more than one SSID.