### PR TITLE
Off-by-one check for stale job tickets

### DIFF
--- a/global-functions
+++ b/global-functions
@@ -965,7 +965,7 @@
     $LogPrintExit2 error $0 ("No script '" . $Script . "' is running!") true;
   }
 
-  :if ([ :len ($ScriptLockOrder->$Script) ] > $JobCount) do={
+  :if ([ :len ($ScriptLockOrder->$Script) ] >= $JobCount) do={
     $LogPrintExit2 error $0 ("More tickets than running scripts '" . $Script . "', resetting!") false;
     :set ($ScriptLockOrder->$Script);
     / system script job remove [ find where script=$Script ];


### PR DESCRIPTION
You need to have a think about this one, I'm not sure I have it right.

I had a stale ticket
```
[admin@wapR-LTE1] /system/script/job> :put [ :len [ / system script job find where script=sms-forward  ] ]
0
[admin@wapR-LTE1] /system/script/job> :put $ScriptLockOrder
log-forward=;sms-forward=b3a0cd9502c42ea3e5c7
```

When the code gets to the part I've changed, `$JobCount` is 1 for the new script and there is 1 ticket, for the stale ticket. The new job doesn't add its ticket until after this check. So in my thinking, if the ticket count is equal to the job count then there is an error.
