### PR TITLE
Update unattended-lte-firmware-upgrade.rsc - Omit `once`

### DIFF
--- a/unattended-lte-firmware-upgrade.rsc
+++ b/unattended-lte-firmware-upgrade.rsc
@@ -10,7 +10,7 @@
   :local Firmware;
   :local IntName [ /interface/lte/get $Interface name ];
   :do {
-    :set Firmware [ /interface/lte/firmware-upgrade $Interface once as-value ];
+    :set Firmware [ /interface/lte/firmware-upgrade $Interface as-value ];
   } on-error={
     :log debug ("Could not get latest LTE firmware version for interface " . $IntName . ".");
   }


### PR DESCRIPTION
Omit `once` from the `lte/firmware-upgrade $IntName as-value` command.

Closes #69

Before

```
[admin@RBLHGGR] > /system/script/run check-lte-firmware-upgrade 
info: An empty string is not a valid version.
```

After

```
[admin@RBLHGGR] > /system/script/run check-lte-firmware-upgrade 
info: No firmware upgrade available for LTE interface lte1.
```