### PR TITLE
Fix curl false positives when default capath contains system certs

### DIFF
--- a/certs/Makefile
+++ b/certs/Makefile
@@ -29,4 +29,4 @@ DOMAINS = \
 all: $(DOMAINS)
 
 $(DOMAINS):
-	curl --output /dev/null --silent --connect-timeout 5 --cacert $(notdir $@).pem https://$(dir $@)
+	curl --output /dev/null --silent --connect-timeout 5 --capath /dev/null --cacert $(notdir $@).pem https://$(dir $@)


### PR DESCRIPTION
If curl has a default capath (debian 12 capath=/etc/ssl/certs) it will add those certs and return ok to any valid https url, defeating the intended use of the cacert option in the Makefile that validates sites and certs.

To avoid that, adding option "--capath /dev/null" overrides the default value, if any.