### PR TITLE
Fix file exists condition in SSHKeysImportFile

### DIFF
--- a/mod/ssh-keys-import.rsc
+++ b/mod/ssh-keys-import.rsc
@@ -85,7 +85,7 @@
     :return false;
   }
 
-  :if ([ $FileExists $FileName ] = true) do={
+  :if ([ $FileExists $FileName ] = false) do={
     $LogPrint warning $0 ("File '" . $FileName . "' does not exist.");
     :return false;
   }


### PR DESCRIPTION
Fix the typo 

```
if FileExists = true then
    $LogPrint ("File does not exist.")

```
inside the function SSHKeysFileImport from mod/ssh-keys-import.rsc
