### PR TITLE
Configurable domain parameter for CNAME record

### DIFF
--- a/dhcp-to-dns.rsc
+++ b/dhcp-to-dns.rsc
@@ -17,6 +17,7 @@
   :local ScriptName [ :jobname ];
 
   :global Domain;
+  :global DhcpToDnsCnameDomain;
   :global Identity;
 
   :global CleanName;
@@ -71,7 +72,8 @@
     :if ([ :len ($LeaseVal->"active-address") ] > 0) do={
       :local Comment ($CommentPrefix . ", macaddress=" . $LeaseVal->"active-mac-address" . ", server=" . $LeaseVal->"server");
       :local MacDash [ $CleanName ($LeaseVal->"active-mac-address") ];
-      :local HostName [ $CleanName [ $EitherOr ([ $ParseKeyValueStore ($LeaseVal->"comment") ]->"hostname") ($LeaseVal->"host-name") ] ];
+      :local LeaseInfo [ $ParseKeyValueStore ($LeaseVal->"comment") ];
+      :local HostName [ $CleanName [ $EitherOr ($LeaseInfo->"hostname") ($LeaseVal->"host-name") ] ];
       :local Network [ /ip/dhcp-server/network/find where ($LeaseVal->"active-address") in address ];
       :local NetworkVal;
       :if ([ :len $Network ] > 0) do={
@@ -81,7 +83,8 @@
       :local NetDomain ([ $IfThenElse ([ :len ($NetworkInfo->"name-extra") ] > 0) ($NetworkInfo->"name-extra" . ".") ] . \
         [ $EitherOr [ $EitherOr ($NetworkInfo->"domain") ($NetworkVal->"domain") ] $Domain ]);
       :local FullA ($MacDash . "." . $NetDomain);
-      :local FullCN ($HostName . "." . $NetDomain);
+      :local CnameDomain [ $EitherOr ($LeaseInfo->"cname-domain") [ $EitherOr ($NetworkInfo->"cname-domain") $DhcpToDnsCnameDomain ] ];
+      :local FullCN ($HostName . "." . [ $IfThenElse ([ :len $CnameDomain ] > 0) $CnameDomain $NetDomain ]);
       :local MacInServer ($LeaseVal->"active-mac-address" . " in " . $LeaseVal->"server");
 
       :local DnsRecord [ /ip/dns/static/find where comment=$Comment type=A ];

--- a/dhcp-to-dns.rsc
+++ b/dhcp-to-dns.rsc
@@ -71,9 +71,9 @@
 
     :if ([ :len ($LeaseVal->"active-address") ] > 0) do={
       :local Comment ($CommentPrefix . ", macaddress=" . $LeaseVal->"active-mac-address" . ", server=" . $LeaseVal->"server");
-      :local MacDash [ $CleanName ($LeaseVal->"active-mac-address") ];
+      :local MacDash [ :tolower [ $CleanName ($LeaseVal->"active-mac-address") ] ];
       :local LeaseInfo [ $ParseKeyValueStore ($LeaseVal->"comment") ];
-      :local HostName [ $CleanName [ $EitherOr ($LeaseInfo->"hostname") ($LeaseVal->"host-name") ] ];
+      :local HostName [ :tolower [ $CleanName [ $EitherOr ($LeaseInfo->"hostname") ($LeaseVal->"host-name") ] ] ];
       :local Network [ /ip/dhcp-server/network/find where ($LeaseVal->"active-address") in address ];
       :local NetworkVal;
       :if ([ :len $Network ] > 0) do={

--- a/doc/dhcp-to-dns.md
+++ b/doc/dhcp-to-dns.md
@@ -63,6 +63,27 @@ If no domain is found in dhcp server's network definition a fallback from
 
 * `Domain`: the domain used for dns records
 
+### Override domain for CNAME records
+
+By default both the A record (based on mac address) and the CNAME record
+(based on host name) use the same domain. You can set a different domain
+for CNAME records at three levels (in order of priority):
+
+**Per lease** — add `cname-domain=` to the lease comment:
+
+    /ip/dhcp-server/lease/add address=10.0.0.50 comment="hostname=mydevice, cname-domain=example.com" mac-address=00:11:22:33:44:55 server=dhcp;
+
+**Per network** — add `cname-domain=` to the network comment:
+
+    /ip/dhcp-server/network/add address=10.0.0.0/24 domain=dhcp.example.com comment="name-extra=v10, cname-domain=example.com";
+
+This would result in A record `00-11-22-33-44-55.v10.dhcp.example.com` and
+CNAME record `mydevice.example.com` for the same lease.
+
+**Globally** — set the parameter in `global-config-overlay`:
+
+* `DhcpToDnsCnameDomain`: domain used for CNAME records; leave empty (default) to use the same domain as A records
+
 > ℹ️ **Info**: Copy relevant configuration from
 > [`global-config`](../global-config.rsc) (the one without `-overlay`) to
 > your local `global-config-overlay` and modify it to your specific needs.

--- a/global-config.rsc
+++ b/global-config.rsc
@@ -22,6 +22,11 @@
 # and backup scripts for file names.
 :global Domain "example.com";
 
+# Override domain used for CNAME records in dhcp-to-dns. Can also be set
+# per network or per lease via 'cname-domain=...' in their comment.
+# Leave empty to use the same domain as A records (default).
+:global DhcpToDnsCnameDomain "";
+
 # You can send e-mail notifications. Configure the system's mail settings
 # (/tool/e-mail), then install the module:
 # $ScriptInstallUpdate mod/notification-email


### PR DESCRIPTION
Added cname-domain="" just like domain parameter in comments. Works for leases and networks entries. Also I added string normalization for hostnames.