### PR TITLE
Add cname-domain override and lowercase normalization to dhcp-to-dns

### DIFF
--- a/dhcp-to-dns.rsc
+++ b/dhcp-to-dns.rsc
@@ -27,11 +27,26 @@
   :global LogPrintOnce;
   :global ParseKeyValueStore;
   :global ScriptLock;
-  :global ToLower;
 
   :if ([ $ScriptLock $ScriptName 10 ] = false) do={
     :set ExitOK true;
     :error false;
+  }
+
+  :local ToLower do={
+    :local Input [ :tostr $1 ];
+    :local Upper "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    :local Lower "abcdefghijklmnopqrstuvwxyz";
+    :local Return "";
+    :for I from=0 to=([ :len $Input ] - 1) do={
+      :local Char [ :pick $Input $I ];
+      :local Pos [ :find $Upper $Char ];
+      :if ([ :typeof $Pos ] != "nil") do={
+        :set Char [ :pick $Lower $Pos ($Pos + 1) ];
+      }
+      :set Return ($Return . $Char);
+    }
+    :return $Return;
   }
 
   :local Ttl 5m;

--- a/dhcp-to-dns.rsc
+++ b/dhcp-to-dns.rsc
@@ -17,6 +17,7 @@
   :local ScriptName [ :jobname ];
 
   :global Domain;
+  :global DhcpToDnsCnameDomain;
   :global Identity;
 
   :global CleanName;
@@ -26,6 +27,7 @@
   :global LogPrintOnce;
   :global ParseKeyValueStore;
   :global ScriptLock;
+  :global ToLower;
 
   :if ([ $ScriptLock $ScriptName 10 ] = false) do={
     :set ExitOK true;
@@ -70,8 +72,9 @@
 
     :if ([ :len ($LeaseVal->"active-address") ] > 0) do={
       :local Comment ($CommentPrefix . ", macaddress=" . $LeaseVal->"active-mac-address" . ", server=" . $LeaseVal->"server");
-      :local MacDash [ $CleanName ($LeaseVal->"active-mac-address") ];
-      :local HostName [ $CleanName [ $EitherOr ([ $ParseKeyValueStore ($LeaseVal->"comment") ]->"hostname") ($LeaseVal->"host-name") ] ];
+      :local MacDash [ $ToLower [ $CleanName ($LeaseVal->"active-mac-address") ] ];
+      :local LeaseInfo [ $ParseKeyValueStore ($LeaseVal->"comment") ];
+      :local HostName [ $ToLower [ $CleanName [ $EitherOr ($LeaseInfo->"hostname") ($LeaseVal->"host-name") ] ] ];
       :local Network [ /ip/dhcp-server/network/find where ($LeaseVal->"active-address") in address ];
       :local NetworkVal;
       :if ([ :len $Network ] > 0) do={
@@ -81,7 +84,8 @@
       :local NetDomain ([ $IfThenElse ([ :len ($NetworkInfo->"name-extra") ] > 0) ($NetworkInfo->"name-extra" . ".") ] . \
         [ $EitherOr [ $EitherOr ($NetworkInfo->"domain") ($NetworkVal->"domain") ] $Domain ]);
       :local FullA ($MacDash . "." . $NetDomain);
-      :local FullCN ($HostName . "." . $NetDomain);
+      :local CnameDomain [ $EitherOr ($LeaseInfo->"cname-domain") [ $EitherOr ($NetworkInfo->"cname-domain") $DhcpToDnsCnameDomain ] ];
+      :local FullCN ($HostName . "." . [ $IfThenElse ([ :len $CnameDomain ] > 0) $CnameDomain $NetDomain ]);
       :local MacInServer ($LeaseVal->"active-mac-address" . " in " . $LeaseVal->"server");
 
       :local DnsRecord [ /ip/dns/static/find where comment=$Comment type=A ];

--- a/doc/dhcp-to-dns.md
+++ b/doc/dhcp-to-dns.md
@@ -63,6 +63,27 @@ If no domain is found in dhcp server's network definition a fallback from
 
 * `Domain`: the domain used for dns records
 
+### Override domain for CNAME records
+
+By default both the A record (based on mac address) and the CNAME record
+(based on host name) use the same domain. You can set a different domain
+for CNAME records at three levels (in order of priority):
+
+**Per lease** — add `cname-domain=` to the lease comment:
+
+    /ip/dhcp-server/lease/add address=10.0.0.50 comment="hostname=mydevice, cname-domain=example.com" mac-address=00:11:22:33:44:55 server=dhcp;
+
+**Per network** — add `cname-domain=` to the network comment:
+
+    /ip/dhcp-server/network/add address=10.0.0.0/24 domain=dhcp.example.com comment="name-extra=v10, cname-domain=example.com";
+
+This would result in A record `00-11-22-33-44-55.v10.dhcp.example.com` and
+CNAME record `mydevice.example.com` for the same lease.
+
+**Globally** — set the parameter in `global-config-overlay`:
+
+* `DhcpToDnsCnameDomain`: domain used for CNAME records; leave empty (default) to use the same domain as A records
+
 > ℹ️ **Info**: Copy relevant configuration from
 > [`global-config`](../global-config.rsc) (the one without `-overlay`) to
 > your local `global-config-overlay` and modify it to your specific needs.

--- a/global-config.rsc
+++ b/global-config.rsc
@@ -22,6 +22,11 @@
 # and backup scripts for file names.
 :global Domain "example.com";
 
+# Override domain used for CNAME records in dhcp-to-dns. Can also be set
+# per network or per lease via 'cname-domain=...' in their comment.
+# Leave empty to use the same domain as A records (default).
+:global DhcpToDnsCnameDomain "";
+
 # You can send e-mail notifications. Configure the system's mail settings
 # (/tool/e-mail), then install the module:
 # $ScriptInstallUpdate mod/notification-email

--- a/global-functions.rsc
+++ b/global-functions.rsc
@@ -81,7 +81,6 @@
 :global SendNotification2;
 :global SymbolByUnicodeName;
 :global SymbolForNotification;
-:global ToLower;
 :global Unix2Dos;
 :global UrlEncode;
 :global ValidateSyntax;
@@ -301,24 +300,6 @@
   }
 
   :return $Path;
-}
-
-# convert string to lower case
-:set ToLower do={
-  :local Input [ :tostr $1 ];
-  :local Upper "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  :local Lower "abcdefghijklmnopqrstuvwxyz";
-  :local Return "";
-
-  :for I from=0 to=([ :len $Input ] - 1) do={
-    :local Char [ :pick $Input $I ];
-    :local Pos [ :find $Upper $Char ];
-    :if ([ :typeof $Pos ] != "nil") do={
-      :set Char [ :pick $Lower $Pos ($Pos + 1) ];
-    }
-    :set Return ($Return . $Char);
-  }
-  :return $Return;
 }
 
 # clean name for DNS, file and more

--- a/global-functions.rsc
+++ b/global-functions.rsc
@@ -81,6 +81,7 @@
 :global SendNotification2;
 :global SymbolByUnicodeName;
 :global SymbolForNotification;
+:global ToLower;
 :global Unix2Dos;
 :global UrlEncode;
 :global ValidateSyntax;
@@ -300,6 +301,24 @@
   }
 
   :return $Path;
+}
+
+# convert string to lower case
+:set ToLower do={
+  :local Input [ :tostr $1 ];
+  :local Upper "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  :local Lower "abcdefghijklmnopqrstuvwxyz";
+  :local Return "";
+
+  :for I from=0 to=([ :len $Input ] - 1) do={
+    :local Char [ :pick $Input $I ];
+    :local Pos [ :find $Upper $Char ];
+    :if ([ :typeof $Pos ] != "nil") do={
+      :set Char [ :pick $Lower $Pos ($Pos + 1) ];
+    }
+    :set Return ($Return . $Char);
+  }
+  :return $Return;
 }
 
 # clean name for DNS, file and more


### PR DESCRIPTION
Two improvements to dhcp-to-dns:                                                                                                                 
  
  1. Allow a separate domain for CNAME records (A records keep their                                                                               
     MAC-based name in the technical domain, CNAMEs can resolve to a
     cleaner one). Configurable at three levels:                                                                                                   
     - global: DhcpToDnsCnameDomain in global-config-overlay                                                                                       
     - per network: cname-domain= in DHCP network comment                                                                                          
     - per lease: cname-domain= in DHCP lease comment (highest priority)                                                                           
                                                                                                                                                   
  2. Normalize generated DNS names to lowercase. DHCP clients often send                                                                           
     mixed-case hostnames (e.g. DESKTOP-ABC123, iPhone-XYZ). A new                                                                                 
     ToLower helper in global-functions is used for both the MAC-based                                                                             
     A record name and the hostname CNAME.