### PR TITLE
netwatch-dns: fix unset doh-cert

### DIFF
--- a/netwatch-dns.rsc
+++ b/netwatch-dns.rsc
@@ -103,7 +103,7 @@
   }
 
   :foreach DohServer in=$DohServers do={
-    :foreach DohCert in=[ :toarray delimiter=":" ($DohServer->"doh-cert") ] do={
+    :foreach DohCert in=[ :toarray delimiter=":" [ $EitherOr ($DohServer->"doh-cert") "" ] ] do={
       :if ([ :len $DohCert ] > 0) do={
         :if ([ $CertificateAvailable $DohCert "fetch" ] = false || \
              [ $CertificateAvailable $DohCert "dns" ] = false) do={


### PR DESCRIPTION
Fixes netwatch-dns error when `doh-cert` is missing from the comment.

```
  Script 'netwatch-dns' exited with error: input is not a string
```
